### PR TITLE
Split certifier out of the queue consumer

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/main.js | bunyan",
     "start:consumer": "node src/consumer.js",
+    "start:certifier": "node src/certifier.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --ignore-path .gitignore ./src/",
     "lint:js:cached": "eslint --cache --ignore-path .gitignore ./src/",

--- a/backend/src/certifier.js
+++ b/backend/src/certifier.js
@@ -1,0 +1,79 @@
+// Copyright Parity Technologies (UK) Ltd., 2017.
+// Released under the Apache 2/MIT licenses.
+
+'use strict';
+
+const config = require('config');
+
+const Certifier = require('./contracts/certifier');
+const Sale = require('./contracts/sale');
+const Onfido = require('./onfido');
+const store = require('./store');
+const ParityConnector = require('./api/parity');
+const { waitForConfirmations } = require('./utils');
+
+const { ONFIDO_STATUS } = Onfido;
+
+class AccountCertifier {
+  static run (wsUrl, contractAddress) {
+    return new AccountCertifier(wsUrl, contractAddress);
+  }
+
+  constructor (wsUrl, contractAddress) {
+    this._updateLock = false;
+    this._verifyLock = false;
+
+    this._connector = new ParityConnector(wsUrl);
+    this._sale = new Sale(this._connector, contractAddress);
+
+    this._sale.update().then(() => this.init());
+  }
+
+  async init () {
+    try {
+      this._certifier = new Certifier(this._connector, this._sale.values.certifier);
+
+      await store.Onfido.subscribe(async () => this.verifyOnfidos());
+      console.warn('Started account certifier!');
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async verifyOnfidos () {
+    if (this._verifyLock) {
+      return;
+    }
+
+    this._verifyLock = true;
+
+    await store.Onfido.scan(async (href) => this.verifyOnfido(href));
+
+    this._verifyLock = false;
+  }
+
+  async verifyOnfido (href) {
+    try {
+      console.warn('verifying', href);
+      const { address, valid } = await Onfido.verify(href);
+
+      if (valid) {
+        console.warn('certifying', address);
+        const tx = await this._certifier.certify(address);
+
+        await waitForConfirmations(this._connector, tx);
+      }
+
+      await store.Onfido.set(address, {
+        status: ONFIDO_STATUS.COMPLETED,
+        result: valid ? 'success' : 'fail'
+      });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      await store.Onfido.remove(href);
+    }
+  }
+}
+
+AccountCertifier.run(config.get('nodeWs'), config.get('saleContract'));


### PR DESCRIPTION
Splitting the two, will only need to ensure that private key to the trusted account for certifier is not hosted on the public HTTP server.